### PR TITLE
Make access ID to be nullable

### DIFF
--- a/spec/openapi3.yml
+++ b/spec/openapi3.yml
@@ -1719,8 +1719,6 @@ components:
           pattern: '^(\d{4})/(\d{2})/(\d{2}) (\d{2}):(\d{2}):(\d{2}).(\d{3})$'
         card:
           type: object
-          required:
-            - access_id
           properties:
             card_no:
               type: string
@@ -1768,6 +1766,7 @@ components:
               nullable: true
             access_id:
               type: string
+              nullable: true
             acs:
               type: string
               nullable: true


### PR DESCRIPTION
https://docs.fincode.jp/api#tag/%E6%B1%BA%E6%B8%88%E6%89%8B%E6%AE%B5/operation/postPaymentMethods

> access_id | string = 24 characters 3DS2.0成功時のみ値が入る

As mentioned in the reference, access ID is null if the request does not offer 3DSecure.